### PR TITLE
Improve video writer and audio processing

### DIFF
--- a/droplet_video_analyzer/dva.py
+++ b/droplet_video_analyzer/dva.py
@@ -215,6 +215,7 @@ def main():
         # reduce that likelihood.
 
         (video_frame_width, video_frame_height) = frame_processor.frame_shape
+        video_frame_rate = frame_processor.frame_rate
         #
         if CAPTURE_VIDEO:
             # Open the output file.
@@ -230,7 +231,7 @@ def main():
                 # cv2.VideoWriter_fourcc("J", "P", "E", "G"),  # writes unreadable file
                 # cv2.VideoWriter_fourcc("A", "C", "V", "1"),  # works w/msg
                 # cv2.VideoWriter_fourcc("0", "0", "0", "0"),  # bogus entry, works w/msg
-                30,
+                video_frame_rate,
                 (int(video_frame_width), int(video_frame_height)),
                 1,
             )

--- a/utils/ffmpeg_processing.py
+++ b/utils/ffmpeg_processing.py
@@ -143,7 +143,9 @@ def get_normalized_audio_level_by_frame(in_file=None):
     audio = np.frombuffer(out, np.int16)
 
     # Reshape to chunk and eliminate partial frames.
-    samples_per_frame = int(sample_rate // frame_rate)
+    # ceiling sample rate to frame rate for bigger size, 
+    # to avoid audio chunks slightly longer than number of frames
+    samples_per_frame = int(np.ceil(sample_rate / frame_rate))
     audio = audio[: samples_per_frame * (audio.shape[0] // samples_per_frame)].reshape(
         -1, samples_per_frame
     )

--- a/video/FrameDispenser.py
+++ b/video/FrameDispenser.py
@@ -88,6 +88,8 @@ class FrameDispenser:
             self.is_empty = True
             return
 
+        self.frame_rate = round(self._video_file.get(cv2.CAP_PROP_FPS))
+
         self.shape = tuple(
             int(x)
             for x in [

--- a/video/processors.py
+++ b/video/processors.py
@@ -296,6 +296,7 @@ class VideoFrameProcessor:
         self._video_file_output_path = video_file_output_path
         self._frame_dispenser = FrameDispenser(self.file_path, PROCESSED_HISTORY=True)
         self.frame_shape = self._frame_dispenser.shape
+        self.frame_rate = self._frame_dispenser.frame_rate
         # Current unprocessed video frame
         self._frame = None
         # Current finished frame


### PR DESCRIPTION
Changes include:

- implement video writer with original frame rate (to sync sountrack with pictures when input video FPS not equal to fixed 30 FPS);
- reshape audio to bigger chunk size, by _ceiling_ the value `samples_per_frame` in function `get_normalized_audio_level_by_frame` _rather than flooring_ it, to avoid negative index bugs (as below) when length of normalized audio by frame slightly longer than number of frames, although rarely happens.
```
Traceback (most recent call last):
  File "droplet_video_analyzer\dva", line 25, in <module>
    main()
  File "droplet_video_analyzer\droplet_video_analyzer\dva.py", line 204, in main
    DEBUG=DEBUG,
  File "droplet_video_analyzer\video\processors.py", line 370, in __init__
    self.audio_data_by_frame = get_normalized_audio_level_by_frame(self.file_path)
  File "droplet_video_analyzer\utils\ffmpeg_processing.py", line 165, in get_normalized_audio_level_by_frame
    'constant',
  File "<__array_function__ internals>", line 6, in pad
  File "...\numpy\lib\arraypad.py", line 743, in pad
    pad_width = _as_pairs(pad_width, array.ndim, as_index=True)
  File "...\numpy\lib\arraypad.py", line 510, in _as_pairs
    raise ValueError("index can't contain negative values")
ValueError: index can't contain negative values
```